### PR TITLE
Rilascio versione 1.2.4

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,17 @@
+2026-05-12  Giuliano Pintori <pintori@link.it>
+
+	Rilascio versione 1.2.4
+
+2026-05-12  Giuliano Pintori <pintori@link.it>
+
+	Risoluzione segnalazione SonarCloud java:S4507
+	In src/main/java/it/govpay/stampe/mapper/BaseAvvisoMapper.java sostituita
+	la chiamata e.printStackTrace() nel catch del metodo mapLogo con
+	logger.error(...) via SLF4J, coerente con il pattern già adottato negli
+	altri service del progetto (es. AvvisoPagamentoService). Aggiunti i
+	relativi import e dichiarato il Logger nell'interfaccia. Rimossi commenti
+	di debug residui.
+
 2026-05-06  Giuliano Pintori <pintori@link.it>
 
 	Pipeline CI

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>it.govpay.stampe</groupId>
 	<artifactId>stampe-api</artifactId>
-	<version>1.2.3</version>
+	<version>1.2.4</version>
 	<packaging>${packaging.type}</packaging>
 	<name>GovPay - Stampe - API</name>
 	<description>GovPay Modulo per la creazione delle stampe</description>

--- a/src/main/java/it/govpay/stampe/mapper/BaseAvvisoMapper.java
+++ b/src/main/java/it/govpay/stampe/mapper/BaseAvvisoMapper.java
@@ -10,6 +10,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import it.govpay.stampe.beans.Amount;
 import it.govpay.stampe.beans.Creditor;
@@ -24,7 +26,9 @@ import it.govpay.stampe.model.v1.RataAvviso;
 import it.govpay.stampe.utils.AvvisoPagamentoUtils;
 
 public interface BaseAvvisoMapper {
-	
+
+	Logger logger = LoggerFactory.getLogger(BaseAvvisoMapper.class);
+
 	@Mapping(target = "importo", source="amount")
 	@Mapping(target = "data", source="dueDate", qualifiedByName = "mapData")
 	@Mapping(target = "codiceAvviso", source="noticeNumber", qualifiedByName = "mapNumeroAvviso")
@@ -82,14 +86,11 @@ public interface BaseAvvisoMapper {
 		if(logo == null) return null;
 		
 		try {
-	        // Leggi i byte dal file di risorsa del logo
 	        byte[] logoBytes = IOUtils.toByteArray(logo.getInputStream());
-
-	        // Converti i byte in una stringa
 	        return new String(logoBytes);
 	    } catch (IOException e) {
-	        e.printStackTrace(); // o logga l'errore
-	        return null; // o gestisci diversamente l'errore, restituendo una stringa vuota o lanciando un'eccezione
+	        logger.error("Errore durante la lettura del logo", e);
+	        return null;
 	    }
 	}
 


### PR DESCRIPTION
Risoluzione segnalazione SonarCloud java:S4507 in BaseAvvisoMapper.java: sostituita la chiamata e.printStackTrace() nel catch del metodo mapLogo con logger.error(...) via SLF4J, coerente con il pattern adottato negli altri service del progetto.