### PR TITLE
Migrazione a Spring Boot 4.x / Spring Framework 7.x / Jackson 3

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -68,14 +68,23 @@ jobs:
       id: date
       run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
+    - name: Read OWASP plugin version from pom.xml
+      id: owasp
+      run: |
+        VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=owasp.plugin.version)"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "OWASP Dependency-Check version: $VERSION"
+
     - name: Cache OWASP Dependency-Check DB
       id: owasp-cache
       uses: actions/cache@v5
       with:
         path: .dependency-check/data
-        key: ${{ runner.os }}-owasp-${{ steps.date.outputs.date }}
+        # Chiave: versione plugin (bump -> cache invalidata per schema diverso)
+        # + data (allineamento con il refresh giornaliero del DB NVD).
+        key: ${{ runner.os }}-owasp-v${{ steps.owasp.outputs.version }}-${{ steps.date.outputs.date }}
         restore-keys: |
-          ${{ runner.os }}-owasp-
+          ${{ runner.os }}-owasp-v${{ steps.owasp.outputs.version }}-
 
     - name: Build War with Maven
       run: mvn clean install -P war -DskipTests -Ddependency-check.skip=true

--- a/.github/workflows/refresh-owasp-db.yml
+++ b/.github/workflows/refresh-owasp-db.yml
@@ -1,23 +1,58 @@
 name: Refresh OWASP Dependency-Check DB
 
-# Aggiorna il DB NVD ogni notte così la pipeline principale
-# trova sempre una cache calda e non scarica mai il DB completo.
 on:
   schedule:
-    - cron: '0 3 * * *'  # ogni notte alle 03:00 UTC
-  workflow_dispatch:      # avvio manuale (utile al primo setup o dopo una cache eviction)
+    - cron: '0 3 * * *'
+  workflow_dispatch:
 
 permissions:
-  actions: write  # necessario per scrivere la cache cross-workflow
+  actions: write
+
+# ────────────────────────────────────────────────────────────
+#  PANNELLO DI TUNING — modifica qui, non dentro gli step
+# ────────────────────────────────────────────────────────────
+env:
+  # Ritentativi per ogni richiesta all'API NVD prima di arrendersi.
+  # Alzato a 30: assorbe i 503/524 intermittenti tipici della ripresa NVD.
+  NVD_MAX_RETRY_COUNT: "30"
+
+  # Pausa (ms) tra una richiesta NVD e la successiva.
+  # Più alto = più gentile con NVD (meno 524), ma job più lento.
+  # Metti "0" per disattivare la pausa e usare il default della CLI.
+  NVD_API_DELAY: "4000"
+
+  # Timeout (secondi) del solo colpo di preflight (curl -m).
+  # Copre anche il caso 524/hang: oltre questo, preflight = fallito.
+  NVD_PREFLIGHT_TIMEOUT: "30"
+# ────────────────────────────────────────────────────────────
 
 jobs:
   refresh-owasp-db:
     runs-on: ubuntu-latest
+
+    # Tetto massimo di durata del job (minuti). Il default di GitHub è 360.
+    timeout-minutes: 360
+
     permissions:
       contents: read
       actions: write
 
     steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Read OWASP plugin version from pom.xml
+        id: owasp
+        run: |
+          VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=owasp.plugin.version)"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "OWASP Dependency-Check version: $VERSION"
+
       - name: Get date for cache key
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
@@ -27,20 +62,32 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .dependency-check/data
-          key: ${{ runner.os }}-owasp-${{ steps.date.outputs.date }}
+          key: ${{ runner.os }}-owasp-v${{ steps.owasp.outputs.version }}-${{ steps.date.outputs.date }}
           restore-keys: |
-            ${{ runner.os }}-owasp-
+            ${{ runner.os }}-owasp-v${{ steps.owasp.outputs.version }}-
 
-      - name: Set up Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: "21"
+      - name: Check NVD API availability
+        id: nvd_check
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: |
+          echo "Verifico disponibilità endpoint NVD (con API key)..."
+          HTTP_CODE="$(curl -s -o /dev/null -w '%{http_code}' -m "${NVD_PREFLIGHT_TIMEOUT}" \
+            -H "apiKey: ${NVD_API_KEY}" \
+            'https://services.nvd.nist.gov/rest/json/cves/2.0?resultsPerPage=1' \
+            || echo '000')"
+          echo "NVD ha risposto: HTTP $HTTP_CODE"
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "NVD disponibile, procedo con l'update."
+          else
+            echo "::error::NVD non disponibile (HTTP $HTTP_CODE) - update non eseguito, la cache esistente resta valida."
+            exit 1
+          fi
 
       - name: Install OWASP Dependency-Check CLI
         run: |
-          VERSION="12.1.0"
-          curl -sSL "https://github.com/jeremylong/DependencyCheck/releases/download/v${VERSION}/dependency-check-${VERSION}-release.zip" \
+          VERSION="${{ steps.owasp.outputs.version }}"
+          curl -sSL "https://github.com/dependency-check/DependencyCheck/releases/download/v${VERSION}/dependency-check-${VERSION}-release.zip" \
             -o dependency-check.zip
           unzip -q dependency-check.zip
           echo "$PWD/dependency-check/bin" >> $GITHUB_PATH
@@ -49,12 +96,16 @@ jobs:
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: |
+          echo "Tuning: retry=${NVD_MAX_RETRY_COUNT}, delay=${NVD_API_DELAY}ms"
           dependency-check.sh \
             --updateonly \
             --data .dependency-check/data \
-            --nvdApiKey "$NVD_API_KEY"
+            --nvdApiKey "$NVD_API_KEY" \
+            --nvdMaxRetryCount "$NVD_MAX_RETRY_COUNT" \
+            --nvdApiDelay "$NVD_API_DELAY"
 
       - name: Report cache status
+        if: always()
         run: |
           echo "Cache hit on today's key: ${{ steps.owasp-cache.outputs.cache-hit }}"
           echo "DB size: $(du -sh .dependency-check/data 2>/dev/null || echo 'n/a')"

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,50 @@
+2026-06-18  Giuliano Pintori <pintori@link.it>
+
+	* [Build]
+	Avanzamento versione 2.0.0-SNAPSHOT.
+	Aggiornato parent govpay-bom alla versione 2.0.0-SNAPSHOT (Spring Boot 4.1.0,
+	Spring Framework 7.0.8, Jackson 3).
+
+	* [Migrazione]
+	Migrazione a Spring Boot 4.x / Spring Framework 7.x / Jackson 3.
+	Jackson 2 -> Jackson 3 (package tools.jackson): l'ObjectMapper e' ora immutabile
+	e configurato tramite builder. La personalizzazione del mapper primario (timezone
+	e deserializer custom per i campi Resource via SimpleModule) e' migrata da
+	Jackson2ObjectMapperBuilderCustomizer al nuovo JsonMapperBuilderCustomizer in
+	Application. Ripristinata l'inclusione dei campi null nelle risposte (ALWAYS), che
+	Jackson 3 omette per default. Il supporto a java.time e' ora integrato in
+	jackson-databind (rimossi il modulo JavaTimeModule e la dipendenza
+	jackson-datatype-jsr310). Le API di lettura/scrittura sollevano l'unchecked
+	JacksonException; il deserializer/serializer custom non possono piu' ricevere un
+	tipo gestito null (passata la classe esplicita).
+	Spring Framework 7: javax.annotation.Nullable -> JSpecify
+	org.jspecify.annotations.Nullable; javax.annotation.PostConstruct ->
+	jakarta.annotation.PostConstruct nei service.
+	Rimosso spring-boot-starter-hateoas (non utilizzato); rimossa la dipendenza
+	javax.annotation-api; swagger-annotations v1 (io.swagger) -> io.swagger.core.v3
+	(versioni gestite dal BOM).
+
+	* [Test]
+	Lo slice MockMvc/@AutoConfigureMockMvc in Spring Boot 4 e' in un modulo dedicato
+	(spring-boot-webmvc-test): aggiunta la dipendenza di test e aggiornato l'import.
+	Helper di test (ObjectMapperUtils, ResourceSerializer) allineati a Jackson 3.
+
+	* [Sicurezza]
+	Allineata la gestione della cache OWASP delle pipeline a govpay-common: chiave di
+	cache version-aware (include owasp.plugin.version dal pom, cosi' il bump del plugin
+	invalida la cache evitando incompatibilita' di schema del DB NVD). In
+	refresh-owasp-db.yml la versione della CLI dependency-check e' derivata dal pom e
+	l'URL di download aggiornato a github.com/dependency-check.
+	Aggiunte due suppression OWASP (falsi positivi/non applicabili):
+	- CVE-2026-6009 (JasperReports, deserializzazione -> RCE): non applicabile, l'app usa
+	  solo template .jasper predefiniti nel JAR e l'API accetta solo JSON, senza
+	  caricamento di template esterni (stesso vettore gia' analizzato per CVE-2025-10492;
+	  fix presente solo nella serie 7.x, incompatibile con dynamicreports-core 6.20.1).
+	- CVE-2026-54515 (jackson-databind): falso positivo, l'advisory ufficiale
+	  (GHSA-5jmj-h7xm-6q6v) circoscrive la vulnerabilita' a Jackson 3 >= 3.1.0 e < 3.1.4
+	  (corretta in 3.1.4, versione gia' in uso via BOM); OSS Index la associa erroneamente
+	  all'artefatto Jackson 2 transitivo (jackson-databind 2.21.4), non interessato.
+
 2026-05-12  Giuliano Pintori <pintori@link.it>
 
 	Rilascio versione 1.2.4

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.gov4j.govpay</groupId>
 		<artifactId>govpay-bom</artifactId>
-		<version>1.1.3</version>
+		<version>2.0.0-SNAPSHOT</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>it.govpay.stampe</groupId>
 	<artifactId>stampe-api</artifactId>
-	<version>1.2.4</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<packaging>${packaging.type}</packaging>
 	<name>GovPay - Stampe - API</name>
 	<description>GovPay Modulo per la creazione delle stampe</description>
@@ -30,14 +30,8 @@
 		<maven.install.plugin.version>2.5.2</maven.install.plugin.version>
 		<exec.maven.plugin.versione>1.6.0</exec.maven.plugin.versione>
 
-		<!-- Swagger-codegen -->
+		<!-- Swagger-codegen (versione gestita dal BOM, qui mantenuta esplicita per il plugin) -->
 		<openapi.tool.codegen.version>6.6.0</openapi.tool.codegen.version>
-
-		<!-- Javax -->
-		<javax.annotation.version>1.3.2</javax.annotation.version>
-
-		<!-- Swagger-annotations -->
-		<swagger-annotations.version>1.6.2</swagger-annotations.version>
 
 		<!-- annotazione bean generati notnull -->
 		<jsr305.version>3.0.2</jsr305.version>
@@ -62,8 +56,6 @@
 		<dynamicreports-core.version>6.20.1</dynamicreports-core.version>
 		<!-- jasperreports -->
 		<jasperreports.version>6.21.5</jasperreports.version>
-		
-		<javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 
 		<!-- ant version -->
 		<ant.version>1.10.15</ant.version>
@@ -200,15 +192,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>javax.annotation</groupId>
-			<artifactId>javax.annotation-api</artifactId>
-			<version>${javax.annotation-api.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>io.swagger</groupId>
+			<groupId>io.swagger.core.v3</groupId>
 			<artifactId>swagger-annotations</artifactId>
-			<version>${swagger-annotations.version}</version>
 		</dependency>
 
 		<dependency>
@@ -223,11 +208,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-jsr310</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 		</dependency>
@@ -237,7 +217,7 @@
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
 
-		<!-- Annotazioni SpringDoc OpenAPI -->
+		<!-- SpringDoc OpenAPI (Spring Boot 4 / Spring Framework 7) -->
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
@@ -248,11 +228,7 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-hateoas</artifactId>
-		</dependency>
-		
+
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
@@ -466,6 +442,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- Spring Boot 4: lo slice MockMvc/@AutoConfigureMockMvc e' in un modulo dedicato -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-webmvc-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-core</artifactId>
@@ -631,6 +613,8 @@
 				<configuration>
 					<suppressionFiles>
 						<suppressionFile>${owasp.falsePositives.dir}/CVE-2025-10492.xml</suppressionFile>
+						<suppressionFile>${owasp.falsePositives.dir}/CVE-2026-6009.xml</suppressionFile>
+						<suppressionFile>${owasp.falsePositives.dir}/CVE-2026-54515.xml</suppressionFile>
 					</suppressionFiles>
 				</configuration>
 				<executions>

--- a/src/main/java/it/govpay/stampe/Application.java
+++ b/src/main/java/it/govpay/stampe/Application.java
@@ -1,12 +1,18 @@
 package it.govpay.stampe;
 
+import java.util.TimeZone;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.Resource;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import tools.jackson.databind.module.SimpleModule;
 
 import it.govpay.stampe.deserializer.ResourceDeserializer;
 
@@ -21,12 +27,21 @@ public class Application extends SpringBootServletInitializer {
 	String timeZone;
 
 	/**
-	 * Impstazione del timezone nel mapper
+	 * Personalizza il JsonMapper primario di Spring Boot (Jackson 3): impostazione del
+	 * timezone e registrazione del deserializer custom per i campi di tipo Resource.
+	 * Usare il customizer del builder, invece di esporre un bean ObjectMapper, garantisce
+	 * che la configurazione sia applicata al mapper effettivamente usato dai message
+	 * converter HTTP.
 	 */
 	@Bean
-	public Jackson2ObjectMapperBuilderCustomizer jsonCustomizer() {
-		return builder ->  builder.
-				timeZone(this.timeZone).
-				deserializerByType(Resource.class, new ResourceDeserializer());
+	public JsonMapperBuilderCustomizer jsonCustomizer() {
+		SimpleModule resourceModule = new SimpleModule();
+		resourceModule.addDeserializer(Resource.class, new ResourceDeserializer());
+
+		return builder -> builder
+				.defaultTimeZone(TimeZone.getTimeZone(this.timeZone))
+				// Jackson 3 di default omette i null: ripristina l'inclusione dei null nelle risposte
+				.changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.ALWAYS))
+				.addModule(resourceModule);
 	}
 }

--- a/src/main/java/it/govpay/stampe/deserializer/ResourceDeserializer.java
+++ b/src/main/java/it/govpay/stampe/deserializer/ResourceDeserializer.java
@@ -1,22 +1,22 @@
 package it.govpay.stampe.deserializer;
 
-import java.io.IOException;
 import java.util.Base64;
 
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class ResourceDeserializer extends StdDeserializer<Resource> {
 
     private static final long serialVersionUID = 1L;
 
 	public ResourceDeserializer() {
-        this(null);
+        this(Resource.class);
     }
 
     public ResourceDeserializer(Class<?> vc) {
@@ -24,12 +24,11 @@ public class ResourceDeserializer extends StdDeserializer<Resource> {
     }
 
     @Override
-    public Resource deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
-        JsonNode node = jp.getCodec().readTree(jp);
-        String base64Data = node.asText(); 
-//        byte[] data = base64Data.getBytes();
+    public Resource deserialize(JsonParser jp, DeserializationContext ctxt) throws JacksonException {
+        JsonNode node = ctxt.readTree(jp);
+        String base64Data = node.asString();
         byte[] data = Base64.getDecoder().decode(base64Data);
-        
+
         return new ByteArrayResource(data);
     }
 }

--- a/src/main/java/it/govpay/stampe/exception/handlers/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/it/govpay/stampe/exception/handlers/RestResponseEntityExceptionHandler.java
@@ -5,8 +5,7 @@ import java.net.URISyntaxException;
 import java.util.AbstractMap;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
@@ -29,7 +28,7 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import org.springframework.web.util.WebUtils;
 
-import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import tools.jackson.databind.exc.ValueInstantiationException;
 
 import it.govpay.stampe.beans.Problem;
 import it.govpay.stampe.exception.BadRequestException;

--- a/src/main/java/it/govpay/stampe/service/AvvisoBilingueService.java
+++ b/src/main/java/it/govpay/stampe/service/AvvisoBilingueService.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.JAXBException;
 import javax.xml.namespace.QName;

--- a/src/main/java/it/govpay/stampe/service/AvvisoPostaleService.java
+++ b/src/main/java/it/govpay/stampe/service/AvvisoPostaleService.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.JAXBException;
 import javax.xml.namespace.QName;

--- a/src/main/java/it/govpay/stampe/service/AvvisoSempliceService.java
+++ b/src/main/java/it/govpay/stampe/service/AvvisoSempliceService.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.JAXBException;
 import javax.xml.namespace.QName;

--- a/src/main/java/it/govpay/stampe/service/ViolazioneCdsService.java
+++ b/src/main/java/it/govpay/stampe/service/ViolazioneCdsService.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.JAXBException;
 import javax.xml.namespace.QName;

--- a/src/main/resources/owasp/falsePositives/CVE-2026-54515.xml
+++ b/src/main/resources/owasp/falsePositives/CVE-2026-54515.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+        CVE-2026-54515 (CVSS 6.9, CWE-915): bypass di @JsonIgnoreProperties con matching
+        case-insensitive in jackson-databind. Falso positivo per questo progetto.
+        Secondo l'advisory ufficiale (GHSA-5jmj-h7xm-6q6v) la vulnerabilita' riguarda
+        Jackson 3 nelle versioni >= 3.1.0 e < 3.1.4 ed e' corretta nella 3.1.4. Questo
+        progetto usa Jackson 3 alla versione 3.1.4 (gia' patchata, gestita dal govpay-bom).
+        OSS Index associa erroneamente la CVE all'artefatto Jackson 2 (jackson-databind
+        2.21.4), presente solo transitivamente tramite swagger-core-jakarta per la
+        generazione della documentazione OpenAPI e non interessato da questo bug specifico
+        di Jackson 3.
+        Riferimenti: https://github.com/FasterXML/jackson-databind/security/advisories/GHSA-5jmj-h7xm-6q6v
+        Data analisi: 2026-06-18
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@.*$</packageUrl>
+        <cve>CVE-2026-54515</cve>
+    </suppress>
+</suppressions>

--- a/src/main/resources/owasp/falsePositives/CVE-2026-6009.xml
+++ b/src/main/resources/owasp/falsePositives/CVE-2026-6009.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+        CVE-2026-6009 (CVSS 8.7, CWE-502): Java deserialization vulnerability nella JasperReports
+        Library che puo' portare a RCE. Soppresso perche' questa applicazione non e' vulnerabile:
+        utilizza esclusivamente template .jasper predefiniti inclusi nel JAR (canned reports).
+        L'API REST accetta solo dati JSON e non consente il caricamento di template .jasper o JRXML
+        esterni ne' la deserializzazione di oggetti JasperReports non fidati. Il vettore di attacco
+        (deserializzazione di dati/template non fidati) non e' applicabile. Stesso vettore gia'
+        analizzato per CVE-2025-10492.
+        Riferimenti: https://community.jaspersoft.com/advisories/jaspersoft-security-advisory-may-19-2026-jaspersoft-library-cve-2026-6009-r11/
+        Nessuna versione corretta disponibile nella serie 6.x (ultima: 6.21.5); il fix e' presente
+        solo nella serie 7.x, incompatibile con dynamicreports-core 6.20.1 e con i template attuali.
+        Data analisi: 2026-06-18
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/net\.sf\.jasperreports/jasperreports@.*$</packageUrl>
+        <cve>CVE-2026-6009</cve>
+    </suppress>
+</suppressions>

--- a/src/test/java/it/govpay/stampe/test/UC_11_AvvisoRidottoFailTest.java
+++ b/src/test/java/it/govpay/stampe/test/UC_11_AvvisoRidottoFailTest.java
@@ -17,14 +17,14 @@ import jakarta.json.JsonReader;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import it.govpay.stampe.Application;
 import it.govpay.stampe.beans.Instalment;

--- a/src/test/java/it/govpay/stampe/test/UC_1_ViolazioneCdsFailTest.java
+++ b/src/test/java/it/govpay/stampe/test/UC_1_ViolazioneCdsFailTest.java
@@ -15,14 +15,14 @@ import jakarta.json.JsonReader;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import it.govpay.stampe.Application;
 import it.govpay.stampe.beans.CdsViolation;

--- a/src/test/java/it/govpay/stampe/test/UC_2_ViolazioneCdsTest.java
+++ b/src/test/java/it/govpay/stampe/test/UC_2_ViolazioneCdsTest.java
@@ -8,7 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -16,7 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import it.govpay.stampe.Application;
 import it.govpay.stampe.beans.CdsViolation;

--- a/src/test/java/it/govpay/stampe/test/UC_3_AvvisoStandardFailTest.java
+++ b/src/test/java/it/govpay/stampe/test/UC_3_AvvisoStandardFailTest.java
@@ -15,14 +15,14 @@ import jakarta.json.JsonReader;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import it.govpay.stampe.Application;
 import it.govpay.stampe.beans.Iban;

--- a/src/test/java/it/govpay/stampe/test/UC_4_AvvisoStandardTest.java
+++ b/src/test/java/it/govpay/stampe/test/UC_4_AvvisoStandardTest.java
@@ -8,7 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -16,7 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import it.govpay.stampe.Application;
 import it.govpay.stampe.beans.PaymentNotice;

--- a/src/test/java/it/govpay/stampe/test/UC_5_AvvisoBilingueTest.java
+++ b/src/test/java/it/govpay/stampe/test/UC_5_AvvisoBilingueTest.java
@@ -8,7 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -16,7 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import it.govpay.stampe.Application;
 import it.govpay.stampe.beans.PaymentNotice;

--- a/src/test/java/it/govpay/stampe/test/UC_6_RicevutaTest.java
+++ b/src/test/java/it/govpay/stampe/test/UC_6_RicevutaTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -20,7 +20,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import it.govpay.stampe.Application;
 import it.govpay.stampe.beans.Payer;

--- a/src/test/java/it/govpay/stampe/test/UC_7_RicevutaFailTest.java
+++ b/src/test/java/it/govpay/stampe/test/UC_7_RicevutaFailTest.java
@@ -18,14 +18,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import it.govpay.stampe.Application;
 import it.govpay.stampe.beans.Payer;

--- a/src/test/java/it/govpay/stampe/test/UC_9_AvvisoRidottoTest.java
+++ b/src/test/java/it/govpay/stampe/test/UC_9_AvvisoRidottoTest.java
@@ -8,7 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -16,7 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import it.govpay.stampe.Application;
 import it.govpay.stampe.beans.PaymentNotice;

--- a/src/test/java/it/govpay/stampe/test/serializer/ObjectMapperUtils.java
+++ b/src/test/java/it/govpay/stampe/test/serializer/ObjectMapperUtils.java
@@ -6,12 +6,11 @@ import java.util.TimeZone;
 import org.apache.commons.lang3.time.DateFormatUtils;
 import org.springframework.core.io.ByteArrayResource;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.cfg.EnumFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
 
 public class ObjectMapperUtils {
 
@@ -19,19 +18,20 @@ public class ObjectMapperUtils {
 		SimpleDateFormat sdf = new SimpleDateFormat(DateFormatUtils.ISO_8601_EXTENDED_DATE_FORMAT.getPattern());
 		sdf.setTimeZone(TimeZone.getTimeZone("Europe/Rome"));
 		sdf.setLenient(false);
-		
+
+		// Serializer custom per i campi di tipo ByteArrayResource (PDF in base64)
 		SimpleModule module = new SimpleModule();
 		module.addSerializer(ByteArrayResource.class, new ResourceSerializer());
-		
-		ObjectMapper mapper = JsonMapper.builder().build();
-		mapper.registerModule(module);
-		mapper.registerModule(new JavaTimeModule());
-		mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
-		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-		mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
-		mapper.enable(SerializationFeature.WRITE_DATES_WITH_ZONE_ID); 
-		mapper.setDateFormat(sdf);
-		
-		return mapper;
+
+		// In Jackson 3 l'ObjectMapper e' immutabile: ogni configurazione va impostata sul builder.
+		// Il supporto a java.time e' integrato in jackson-databind (niente JavaTimeModule esplicito).
+		return JsonMapper.builder()
+				.addModule(module)
+				.enable(EnumFeature.READ_ENUMS_USING_TO_STRING)
+				.disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+				.enable(EnumFeature.WRITE_ENUMS_USING_TO_STRING)
+				.enable(DateTimeFeature.WRITE_DATES_WITH_ZONE_ID)
+				.defaultDateFormat(sdf)
+				.build();
 	}
 }

--- a/src/test/java/it/govpay/stampe/test/serializer/ResourceSerializer.java
+++ b/src/test/java/it/govpay/stampe/test/serializer/ResourceSerializer.java
@@ -1,19 +1,18 @@
 package it.govpay.stampe.test.serializer;
 
-import java.io.IOException;
-
 import org.springframework.core.io.ByteArrayResource;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class ResourceSerializer extends StdSerializer<ByteArrayResource> {
 
 	private static final long serialVersionUID = 1L;
 
 	public ResourceSerializer() {
-		this(null);
+		this(ByteArrayResource.class);
 	}
 
 	public ResourceSerializer(Class<ByteArrayResource> t) {
@@ -21,7 +20,7 @@ public class ResourceSerializer extends StdSerializer<ByteArrayResource> {
 	}
 
 	@Override
-	public void serialize(ByteArrayResource value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-		gen.writeBinary(value.getInputStream(), (int) value.contentLength());
+	public void serialize(ByteArrayResource value, JsonGenerator gen, SerializationContext provider) throws JacksonException {
+		gen.writeBinary(value.getByteArray());
 	}
 }


### PR DESCRIPTION
Avanzamento alla versione 2.0.0-SNAPSHOT su parent govpay-bom 2.0.0-SNAPSHOT (Spring Boot 4.1.0, Spring Framework 7.0.8, Jackson 3).

- Jackson 2 -> Jackson 3 (tools.jackson): customizer del mapper primario migrato a JsonMapperBuilderCustomizer (timezone + ResourceDeserializer via SimpleModule); inclusione dei null ripristinata ad ALWAYS; supporto java.time integrato in jackson-databind (rimossi JavaTimeModule e jackson-datatype-jsr310); eccezioni JacksonException; tipo gestito esplicito nei (de)serializer custom.
- Spring 7: javax.annotation.Nullable -> JSpecify; javax.annotation.PostConstruct ->
  jakarta.annotation.PostConstruct nei service.
- pom: parent e versione 2.0.0-SNAPSHOT; rimossi spring-boot-starter-hateoas (non usato), javax.annotation-api e jackson-datatype-jsr310; swagger-annotations v1 -> io.swagger.core.v3 (versioni gestite dal BOM); aggiunto spring-boot-webmvc-test per lo slice @AutoConfigureMockMvc.
- Test allineati a Jackson 3 e al nuovo import di @AutoConfigureMockMvc.
- Pipeline OWASP: cache version-aware su owasp.plugin.version; refresh-owasp-db con versione CLI derivata dal pom e URL github.com/dependency-check.
- Sicurezza: suppression OWASP per CVE-2026-6009 (JasperReports, non applicabile: solo template predefiniti, API JSON-only) e CVE-2026-54515 (falso positivo: la CVE riguarda Jackson 3 < 3.1.4, gia' patchata; OSS Index la associa erroneamente al Jackson 2 transitivo).